### PR TITLE
Update opcua-iiot-core-listener.ts

### DIFF
--- a/src/core/opcua-iiot-core-listener.ts
+++ b/src/core/opcua-iiot-core-listener.ts
@@ -391,7 +391,7 @@ const buildNewEventItem = function (nodeId: TodoTypeAny, msg: TodoTypeAny, subsc
           samplingInterval: interval,
           discardOldest: true,
           queueSize: queueSize,
-          filter: msg.payload.eventFilter
+          filter: msg.payload.uaEventFilter
         },
         TimestampsToReturn.Both,
         function (err: Error, monitoredItemResult: TodoTypeAny) {


### PR DESCRIPTION
Changing 'eventFilter' Property in BuildNewEventItem function to 'uaEventFilter' (according to the output of the OPCUA-iiot-Event node.

The node **OPCUA-iiot-Event** is sending 'uaEventFilter' Property in payload. But the Listener node building a new event from the filter property 'eventFilter' in msg.payload. This difference prevents that any event properties will returned (causing the wrong or empty filter).